### PR TITLE
Docker build fails due to hardcoded libssl1.1 version no longer available #16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,9 @@ RUN apt -y install sudo init python3-pip python3-dev software-properties-common 
 # Install llvm 15
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && rm llvm.sh
 RUN arch=$(dpkg --print-architecture) \
-    && wget https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u3_${arch}.deb \
-    && dpkg -i libssl1.1_1.1.1w-0+deb11u3_${arch}.deb \
-    && rm libssl1.1_1.1.1w-0+deb11u3_${arch}.deb
+    && wget https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u4_${arch}.deb \
+    && dpkg -i libssl1.1_1.1.1w-0+deb11u4_${arch}.deb \
+    && rm libssl1.1_1.1.1w-0+deb11u4_${arch}.deb
 
 # Clone and build wdissector
 RUN git clone https://github.com/asset-group/5ghoul-5g-nr-attacks /root/wdissector


### PR DESCRIPTION
Suggested fix for issue #16 - Docker build fails due to hardcoded libssl1.1 version no longer available.