### PR TITLE
Docker build fails due to hardcoded libssl1.1 version no longer available #16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,10 +68,12 @@ RUN apt -y install sudo init python3-pip python3-dev software-properties-common 
         libzstd1 libunwind8 libcap2 libspeexdsp1 libxtst6 libatk-bridge2.0-0 libusb-1.0-0 meson
 # Install llvm 15
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15 && rm llvm.sh
-RUN arch=$(dpkg --print-architecture) \
-    && wget https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u4_${arch}.deb \
-    && dpkg -i libssl1.1_1.1.1w-0+deb11u4_${arch}.deb \
-    && rm libssl1.1_1.1.1w-0+deb11u4_${arch}.deb
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends debian-archive-keyring ca-certificates \
+    && echo "deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/debian-bullseye.list \
+    && echo "deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://security.debian.org/debian-security bullseye-security main" > /etc/apt/sources.list.d/debian-bullseye-security.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends libssl1.1
 
 # Clone and build wdissector
 RUN git clone https://github.com/asset-group/5ghoul-5g-nr-attacks /root/wdissector


### PR DESCRIPTION
The Dockerfile currently installs libssl1.1 by downloading a specific Debian security package revision. Debian security repositories rotate patch versions over time (for example, deb11u3 → deb11u4 → deb11u5), which causes recurring Docker build failures when older revisions are removed.

This change installs libssl1.1 from the Debian Bullseye/Bullseye-security repositories via apt, allowing the latest compatible revision to be resolved automatically and preventing future build breakage caused by hardcoded package URLs.

The image builds successfully after this change. Minimal runtime validation confirms that relevant wdissector binaries load correctly with libssl1.1.

Debian security patch revisions for OpenSSL 1.1 do not change the library ABI or SONAME, so resolving the latest available revision through the package manager is expected to remain runtime-compatible with existing binaries.